### PR TITLE
Bugfix: requestLogger re: query/params/body

### DIFF
--- a/helpers/requestLogger.js
+++ b/helpers/requestLogger.js
@@ -62,11 +62,11 @@ let requestLogger = (req, res, next) => {
     let log = `[${coloredDate}] ${coloredMethod} ${url} ${coloredStatus} ${coloredDuration}`
     console.info(log)
 
-    if (Object.keys(req.query).length > 0)
+    if (req.query && Object.keys(req.query).length > 0)
       console.info(chalk.blue(`Query: ${JSON.stringify(req.query)}`))
-    if (Object.keys(req.params).length > 0)
+    if (req.params && Object.keys(req.params).length > 0)
       console.info(chalk.blue(`Params: ${JSON.stringify(req.params)}`))
-    if (Object.keys(req.body).length > 0)
+    if (req.body && Object.keys(req.body).length > 0)
       console.info(chalk.blue(`Body: ${JSON.stringify(req.body)}`))
   })
 


### PR DESCRIPTION
* Fix: Throws error if req.query, req.params, req.body do not exist